### PR TITLE
Moved scopes into credentials section and added handling for :skip_info

### DIFF
--- a/lib/omniauth/strategies/angellist.rb
+++ b/lib/omniauth/strategies/angellist.rb
@@ -40,9 +40,17 @@ module OmniAuth
           "roles" => raw_info["roles"],
           "angellist_url" => raw_info["angellist_url"],
           "image" => raw_info["image"],
-          "skills" => raw_info["skills"],
-          "scopes" => raw_info["scopes"]
+          "skills" => raw_info["skills"]
         }
+      end
+
+      credentials do
+        hash = {'token' => access_token.token}
+        hash.merge!('refresh_token' => access_token.refresh_token) if access_token.expires? && access_token.refresh_token
+        hash.merge!('expires_at' => access_token.expires_at) if access_token.expires?
+        hash.merge!('expires' => access_token.expires?)
+        hash.merge!('scope' => raw_info["scopes"] ? raw_info["scopes"].join(" ") : nil)
+        prune!(hash)
       end
 
       def raw_info

--- a/lib/omniauth/strategies/angellist.rb
+++ b/lib/omniauth/strategies/angellist.rb
@@ -25,7 +25,7 @@ module OmniAuth
       uid { raw_info['id'] }
 
       info do
-        {
+        prune!({
           "name" => raw_info["name"],
           "email" => raw_info["email"],
           "bio" => raw_info["bio"],
@@ -41,7 +41,7 @@ module OmniAuth
           "angellist_url" => raw_info["angellist_url"],
           "image" => raw_info["image"],
           "skills" => raw_info["skills"]
-        }
+        })
       end
 
       credentials do
@@ -54,7 +54,11 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('https://api.angel.co/1/me').parsed
+        unless skip_info?
+          @raw_info ||= access_token.get('https://api.angel.co/1/me').parsed
+        else
+          {}
+        end
       end
 
       def authorize_params

--- a/lib/omniauth/strategies/angellist.rb
+++ b/lib/omniauth/strategies/angellist.rb
@@ -75,6 +75,14 @@ module OmniAuth
           params[:scope] ||= DEFAULT_SCOPE
         end
       end
+
+    private
+      def prune!(hash)
+        hash.delete_if do |_, value|
+          prune!(value) if value.is_a?(Hash)
+          value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        end
+      end
     end
   end
 end

--- a/spec/omniauth/strategies/angellist_spec.rb
+++ b/spec/omniauth/strategies/angellist_spec.rb
@@ -7,6 +7,39 @@ describe OmniAuth::Strategies::AngelList do
     @request.stub(:params) { {} }
     @client_id = '123'
     @client_secret = 'afalsf'
+    @raw_info = {
+      'name' => 'Sebastian Rabuini',
+      'email' => 'sebas@wasabit.com.ar',
+      'bio' => 'Sebas',
+      'blog_url' => 'sebas_blog',
+      'online_bio_url' => 'http://wasabitlabs.com',
+      'twitter_url' => 'http://twitter.com/#!/sebasr',
+      'facebook_url' => 'http://www.facebook.com/sebastian.rabuini',
+      'linkedin_url' => 'http://www.linkedin.com/in/srabuini',
+      'follower_count' => 6,
+      'investor' => false,
+      'locations' => [
+        {'id' => 1963, 'tag_type' => 'LocationTag', 'name' => 'buenos aires',
+          'display_name' => 'Buenos Aires',
+          'angellist_url' => 'https://angel.co/buenos-aires'}
+      ],
+      'roles' => [
+        {'id' => 14726, 'tag_type' => 'RoleTag', 'name' => 'developer',
+          'display_name' => 'Developer',
+          'angellist_url' => 'https://angel.co/developer'},
+        {'id' => 14725, 'tag_type' => 'RoleTag', 'name' => 'entrepreneur',
+          'display_name' => 'Entrepreneur',
+          'angellist_url' => 'https://angel.co/entrepreneur-1'}
+      ],
+      'skills' => [
+        {"id" => 82532, "tag_type" => "SkillTag", "name" => "ruby on rails",
+          "display_name" => "Ruby on Rails",
+          "angellist_url" => "https://angel.co/ruby-on-rails-1"}
+      ],
+      'scopes' => ["email","comment","message","talent"],
+      'angellist_url' => 'https://angel.co/sebasr',
+      'image' => 'https://s3.amazonaws.com/photos.angel.co/users/90585-medium_jpg?1327684569'
+    }
   end
   
   subject do
@@ -34,39 +67,6 @@ describe OmniAuth::Strategies::AngelList do
 
   describe '#info' do
     before :each do
-      @raw_info = {
-        'name' => 'Sebastian Rabuini',
-        'email' => 'sebas@wasabit.com.ar',
-        'bio' => 'Sebas',
-        'blog_url' => 'sebas_blog',
-        'online_bio_url' => 'http://wasabitlabs.com',
-        'twitter_url' => 'http://twitter.com/#!/sebasr',
-        'facebook_url' => 'http://www.facebook.com/sebastian.rabuini',
-        'linkedin_url' => 'http://www.linkedin.com/in/srabuini',
-        'follower_count' => 6,
-        'investor' => false,
-        'locations' => [
-          {'id' => 1963, 'tag_type' => 'LocationTag', 'name' => 'buenos aires',
-            'display_name' => 'Buenos Aires',
-            'angellist_url' => 'https://angel.co/buenos-aires'}
-        ],
-        'roles' => [
-          {'id' => 14726, 'tag_type' => 'RoleTag', 'name' => 'developer',
-            'display_name' => 'Developer',
-            'angellist_url' => 'https://angel.co/developer'},
-          {'id' => 14725, 'tag_type' => 'RoleTag', 'name' => 'entrepreneur',
-            'display_name' => 'Entrepreneur',
-            'angellist_url' => 'https://angel.co/entrepreneur-1'}
-        ],
-        'skills' => [
-          {"id" => 82532, "tag_type" => "SkillTag", "name" => "ruby on rails",
-            "display_name" => "Ruby on Rails",
-            "angellist_url" => "https://angel.co/ruby-on-rails-1"}
-        ],
-        'scopes' => ["email","comment","message","talent"],
-        'angellist_url' => 'https://angel.co/sebasr',
-        'image' => 'https://s3.amazonaws.com/photos.angel.co/users/90585-medium_jpg?1327684569'
-      }
       subject.stub(:raw_info) { @raw_info }
     end
     
@@ -85,10 +85,6 @@ describe OmniAuth::Strategies::AngelList do
 
       it "return the email" do
         subject.info['email'].should eq('sebas@wasabit.com.ar')
-      end
-
-      it "return scopes" do
-        subject.credentials['scope'].should eq("email comment message talent")
       end
 
       it "return skills" do
@@ -110,11 +106,12 @@ describe OmniAuth::Strategies::AngelList do
   describe '#credentials' do
     before :each do
       @access_token = double('OAuth2::AccessToken')
-      @access_token.stub(:token)
+      @access_token.stub(:token) { '123' } # Token is always required
       @access_token.stub(:expires?)
       @access_token.stub(:expires_at)
       @access_token.stub(:refresh_token)
       subject.stub(:access_token) { @access_token }
+      subject.stub(:raw_info) { @raw_info }
     end
     
     it 'returns a Hash' do
@@ -122,8 +119,11 @@ describe OmniAuth::Strategies::AngelList do
     end
     
     it 'returns the token' do
-      @access_token.stub(:token) { '123' }
       subject.credentials['token'].should eq('123')
+    end
+
+    it "return scopes" do
+      subject.credentials['scope'].should eq("email comment message talent")
     end
     
     it 'returns the expiry status' do

--- a/spec/omniauth/strategies/angellist_spec.rb
+++ b/spec/omniauth/strategies/angellist_spec.rb
@@ -88,7 +88,7 @@ describe OmniAuth::Strategies::AngelList do
       end
 
       it "return scopes" do
-        subject.info['scopes'].should eq(["email","comment","message","talent"])
+        subject.credentials['scope'].should eq("email comment message talent")
       end
 
       it "return skills" do

--- a/spec/omniauth/strategies/angellist_spec.rb
+++ b/spec/omniauth/strategies/angellist_spec.rb
@@ -41,7 +41,7 @@ describe OmniAuth::Strategies::AngelList do
       'image' => 'https://s3.amazonaws.com/photos.angel.co/users/90585-medium_jpg?1327684569'
     }
   end
-  
+
   subject do
     args = [@client_id, @client_secret, @options].compact
     OmniAuth::Strategies::AngelList.new(nil, *args).tap do |strategy|
@@ -69,7 +69,7 @@ describe OmniAuth::Strategies::AngelList do
     before :each do
       subject.stub(:raw_info) { @raw_info }
     end
-    
+
     context 'when data is present in raw info' do
       it 'returns the combined name' do
         subject.info['name'].should eq('Sebastian Rabuini')
@@ -78,7 +78,7 @@ describe OmniAuth::Strategies::AngelList do
       it 'returns the bio' do
         subject.info['bio'].should eq('Sebas')
       end
-    
+
       it 'returns the image' do
         subject.info['image'].should eq(@raw_info['image'])
       end
@@ -102,7 +102,7 @@ describe OmniAuth::Strategies::AngelList do
       subject.authorize_params['scope'].should eq('email')
     end
   end
-  
+
   describe '#credentials' do
     before :each do
       @access_token = double('OAuth2::AccessToken')
@@ -113,11 +113,11 @@ describe OmniAuth::Strategies::AngelList do
       subject.stub(:access_token) { @access_token }
       subject.stub(:raw_info) { @raw_info }
     end
-    
+
     it 'returns a Hash' do
       subject.credentials.should be_a(Hash)
     end
-    
+
     it 'returns the token' do
       subject.credentials['token'].should eq('123')
     end
@@ -125,15 +125,15 @@ describe OmniAuth::Strategies::AngelList do
     it "return scopes" do
       subject.credentials['scope'].should eq("email comment message talent")
     end
-    
+
     it 'returns the expiry status' do
       @access_token.stub(:expires?) { true }
       subject.credentials['expires'].should eq(true)
-      
+
       @access_token.stub(:expires?) { false }
       subject.credentials['expires'].should eq(false)
     end
-    
+
     it 'returns the refresh token and expiry time when expiring' do
       ten_mins_from_now = (Time.now + 360).to_i
       @access_token.stub(:expires?) { true }
@@ -142,14 +142,14 @@ describe OmniAuth::Strategies::AngelList do
       subject.credentials['refresh_token'].should eq('321')
       subject.credentials['expires_at'].should eq(ten_mins_from_now)
     end
-    
+
     it 'does not return the refresh token when it is nil and expiring' do
       @access_token.stub(:expires?) { true }
       @access_token.stub(:refresh_token) { nil }
       subject.credentials['refresh_token'].should be_nil
       subject.credentials.should_not have_key('refresh_token')
     end
-    
+
     it 'does not return the refresh token when not expiring' do
       @access_token.stub(:expires?) { false }
       @access_token.stub(:refresh_token) { 'XXX' }


### PR DESCRIPTION
I personally worry a bit about the way the omniauth gem handles the credentials section, because there's sadly no way to just `super` this stuff, and there really should be. But the credentials code doesn't change much (last change to it was 2011), so it shouldn't be a big issue.
